### PR TITLE
Fix typo in "enough bags" inline keyboard button label

### DIFF
--- a/src/telegram_writer.rs
+++ b/src/telegram_writer.rs
@@ -41,7 +41,7 @@ async fn weekly_update(bot: &Bot, config: &super::Config, schedule: &TrashesSche
             "new_bags",
         )],
         vec![InlineKeyboardButton::callback(
-            "No. We have enought bags.",
+            "No. We have enough bags.",
             "enough_bags",
         )],
     ]);


### PR DESCRIPTION
The "request new bags" inline keyboard button shown to the food master read
"No. We have enought bags." with a misspelled "enought". This change corrects it
to "enough" in `src/telegram_writer.rs`. It is a single-word fix to a
user-facing string with no behavioral impact, and the project still builds
cleanly.