### PR TITLE
Fix missing verb in daily trash reminder message

### DIFF
--- a/src/telegram_writer.rs
+++ b/src/telegram_writer.rs
@@ -80,7 +80,7 @@ async fn daily_update(
                 .iter()
                 .fold(String::new(), |acc, trash| format!("{} {}", acc, trash));
             let daily_update_txt = format!(
-                "Hello {} !\nDon't forget the{} trashes out before tomorrow morning! \n\
+                "Hello {} !\nDon't forget to put the{} trashes out before tomorrow morning! \n\
                 If you don't answer this message before 9pm,\n\
                 a reminder will be sent to all the flatmates.\n\
                 ",


### PR DESCRIPTION
The daily reminder sent to the food master read "Don't forget the{trashes} trashes out before tomorrow morning!", which is grammatically broken because it is missing a verb. This fixes it to "Don't forget to put the{trashes} trashes out...", matching the phrasing already used in the weekly and shame messages ("put the trashes out"). The change touches a single string literal in `telegram_writer.rs`, alters no logic, and the project compiles cleanly.