### PR TITLE
Fix incorrect reminder deadline in daily food-master message (9pm → 7pm)

### DIFF
--- a/src/telegram_writer.rs
+++ b/src/telegram_writer.rs
@@ -81,7 +81,7 @@ async fn daily_update(
                 .fold(String::new(), |acc, trash| format!("{} {}", acc, trash));
             let daily_update_txt = format!(
                 "Hello {} !\nDon't forget the{} trashes out before tomorrow morning! \n\
-                If you don't answer this message before 9pm,\n\
+                If you don't answer this message before 7pm,\n\
                 a reminder will be sent to all the flatmates.\n\
                 ",
                 schedule.tomorrow_master_name, trashes_str


### PR DESCRIPTION
The daily reminder told the food master that a reminder would be sent to all flatmates if they didn't respond "before 9pm", but the shaming reminder actually fires at 7pm: `compute_next_trigger` only schedules triggers at 16:00 and 19:00, and `send_scheduled_messages` runs `control_human_accomplishment` once `next_trigger.hour() >= 19`. This corrects the user-facing text to "before 7pm" so it matches the real schedule. The change is a single string literal in `telegram_writer.rs` with no behavioral impact, and the project still builds cleanly.