### PR TITLE
Fix grammar in daily trash reminder ("Don't forget to put the trashes out")

### DIFF
--- a/src/telegram_writer.rs
+++ b/src/telegram_writer.rs
@@ -80,7 +80,7 @@ async fn daily_update(
                 .iter()
                 .fold(String::new(), |acc, trash| format!("{} {}", acc, trash));
             let daily_update_txt = format!(
-                "Hello {} !\nDon't forget the{} trashes out before tomorrow morning! \n\
+                "Hello {} !\nDon't forget to put the{} trashes out before tomorrow morning! \n\
                 If you don't answer this message before 9pm,\n\
                 a reminder will be sent to all the flatmates.\n\
                 ",


### PR DESCRIPTION
The daily reminder sent to the food master read "Don't forget the trashes out before tomorrow morning!", which is missing a verb and reads as broken English. This changes it to "Don't forget to put the trashes out before tomorrow morning!", matching the phrasing already used in the weekly and shame reminders ("put these trashes…", "put the trashes out…"). The change touches only a single user-facing string literal, so it cannot affect program logic or break the build.