### PR TITLE
Remove dead "today food master" fields and their wasteful Telegram lookup

### DIFF
--- a/src/data_grabber.rs
+++ b/src/data_grabber.rs
@@ -79,8 +79,6 @@ impl fmt::Display for TrashType {
 #[derive(Debug)]
 pub struct TrashesSchedule {
     pub dates: HashMap<NaiveDate, Vec<TrashType>>,
-    pub _master_name: String,
-    pub _master_id: i64,
     pub tomorrow_master_name: String,
     pub tomorrow_master_id: i64,
 }
@@ -100,40 +98,6 @@ pub async fn grab_tomorrow_food_master_name(config: &super::Config) -> String {
     let bot_token = &config.bot_token;
     let chat_id =
         &config.flatmates[(1 + tomorrow.iso_week().week0() as usize) % config.flatmates.len()];
-
-    let url = format!(
-        "https://api.telegram.org/bot{}/getChat?chat_id={}",
-        bot_token, chat_id
-    );
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .unwrap()
-        .json::<ChatResult>()
-        .await;
-    match response {
-        Ok(response) => {
-            let mut chat_info = response.result;
-            chat_info.title.split_off(17)
-        }
-        Err(_) => "Error".to_string(),
-    }
-}
-
-async fn today_food_master_id(config: &super::Config) -> i64 {
-    let chat_id = config.flatmates
-        [(1 + chrono::Local::now().iso_week().week0() as usize) % config.flatmates.len()];
-    chat_id
-}
-
-async fn grab_today_food_master_name(config: &super::Config) -> String {
-    let client = reqwest::Client::new();
-
-    let bot_token = &config.bot_token;
-    let chat_id = &config.flatmates
-        [(1 + chrono::Local::now().iso_week().week0() as usize) % config.flatmates.len()];
 
     let url = format!(
         "https://api.telegram.org/bot{}/getChat?chat_id={}",
@@ -177,8 +141,6 @@ pub async fn get_trashes(
 
     Ok(TrashesSchedule {
         dates,
-        _master_name: grab_today_food_master_name(config).await,
-        _master_id: today_food_master_id(config).await,
         tomorrow_master_name: grab_tomorrow_food_master_name(config).await,
         tomorrow_master_id: tomorrow_food_master_id(config).await,
     })


### PR DESCRIPTION
## What
Removes the unused `_master_name` and `_master_id` fields from `TrashesSchedule`
and deletes the two functions that backed them (`grab_today_food_master_name`
and `today_food_master_id`).

## Why
- Both fields were prefixed with `_` and never read anywhere in the codebase —
  only `tomorrow_master_name` / `tomorrow_master_id` are actually used.
- Computing `_master_name` on every `get_trashes` call fired an HTTP request to
  the Telegram `getChat` API whose result was immediately discarded, adding
  latency and a needless failure point to each scheduled run.
- The deleted functions were near-verbatim duplicates of their `tomorrow_*`
  counterparts, so dropping them also removes duplication.

## Notes
- Files touched: `src/data_grabber.rs`.
- No call sites needed updating — the removed fields had no readers.
- `cargo build` passes; remaining `cargo clippy` warnings are pre-existing and
  unrelated to this change.