### PR TITLE
Add unit tests for We-Recycle PDF date extraction

### DIFF
--- a/src/data_grabber/we_recycle.rs
+++ b/src/data_grabber/we_recycle.rs
@@ -101,3 +101,55 @@ async fn download_pdf() -> Result<Vec<NaiveDate>, GstaldergeistError> {
     result.sort();
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The PDF dates carry no year, so `extract_dates_from_txt` stamps them with
+    /// the current year. Tests build their expectations against the same year.
+    fn date(day: u32, month: u32) -> NaiveDate {
+        let year = chrono::Utc::now().date_naive().year();
+        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    #[test]
+    fn keeps_only_collection_dates_for_region_19() {
+        // The flat sits in collection region 19, so only rows whose region
+        // column mentions "19" are relevant.
+        let dates = extract_dates_from_txt("05.06. FR 19 ".to_string()).unwrap();
+        assert_eq!(dates, vec![date(5, 6)]);
+    }
+
+    #[test]
+    fn ignores_rows_for_other_regions() {
+        let dates = extract_dates_from_txt("01.01. MO 20 ".to_string()).unwrap();
+        assert!(dates.is_empty());
+    }
+
+    #[test]
+    fn matches_region_19_within_a_range_of_regions() {
+        // Region 19 can appear among several space/plus/dash separated regions.
+        let dates = extract_dates_from_txt("12.07. SA 7 + 19 - 20 ".to_string()).unwrap();
+        assert_eq!(dates, vec![date(12, 7)]);
+    }
+
+    #[test]
+    fn ignores_rows_without_a_region_column() {
+        let dates = extract_dates_from_txt("05.06. FR ".to_string()).unwrap();
+        assert!(dates.is_empty());
+    }
+
+    #[test]
+    fn returns_dates_sorted_ascending() {
+        let text = "12.07. SA 19 \n05.06. FR 19 \n09.06. TU 5 + 19 ".to_string();
+        let dates = extract_dates_from_txt(text).unwrap();
+        assert_eq!(dates, vec![date(5, 6), date(9, 6), date(12, 7)]);
+    }
+
+    #[test]
+    fn returns_empty_when_no_dates_present() {
+        let dates = extract_dates_from_txt("no dates in this text".to_string()).unwrap();
+        assert!(dates.is_empty());
+    }
+}


### PR DESCRIPTION
## What
Adds a `#[cfg(test)]` module covering `extract_dates_from_txt` in
`src/data_grabber/we_recycle.rs` — the function that parses pickup dates out of
the We-Recycle calendar PDF text.

The tests pin down the parser's behaviour:
- keeps a date when its region column mentions region **19** (the flat's region);
- ignores rows for other regions;
- matches region 19 even when it appears inside a `+`/`-` separated list of regions;
- ignores rows that have no region column;
- returns the dates **sorted ascending**;
- returns an empty result when the text contains no dates.

## Why
This was the most intricate piece of pure logic in the codebase (a hand-built
regex plus region filtering) and had **zero** test coverage — the whole project
had no tests at all. The regex is easy to break accidentally during future
tweaks; these tests document the intended parsing rules and guard against
regressions.

## Notes
- Single file touched: `src/data_grabber/we_recycle.rs` (tests only, no
  production-code changes).
- Tests derive the expected year from the current date, matching how the parser
  stamps years, so they stay correct over time.
- `cargo build` and `cargo test` both green (6 new tests pass).
- Independent of the open PRs (#134 deadline text, #137 `format_trashes`
  helper, #138 Adliswil multi-month fetch).