### PR TITLE
Replace panicking config parsing with proper ConfigError handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ pub enum GstaldergeistError {
     #[error("Network error: {0}")]
     NetworkError(reqwest::Error),
 
-    #[allow(dead_code)]
     #[error("Configuration error: {0}")]
     ConfigError(String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,21 +28,34 @@ pub struct Config {
     pub bot_token: String,
 }
 
-fn config() -> Result<Config, error::GstaldergeistError> {
-    let bot_token = env::var("TELEGRAM_BOT_TOKEN").expect("TELEGRAM_BOT_TOKEN not set");
-    let channel_id_str = env::var("TELEGRAM_CHANNEL_ID").expect("TELEGRAM_CHANNEL_ID not set");
-    let channel_id: i64 = channel_id_str
-        .parse()
-        .expect("TELEGRAM_CHANNEL_ID must be a number");
-    let flatmates: String = env::var("TELEGRAM_FLATMATES").expect("TELEGRAM_FLATMATES not set");
-    let flatmates: Vec<i64> = flatmates
-        .split(',')
+fn required_env(name: &str) -> Result<String, error::GstaldergeistError> {
+    env::var(name)
+        .map_err(|_| error::GstaldergeistError::ConfigError(format!("{} not set", name)))
+}
+
+/// Parse a comma-separated list of Telegram chat ids, e.g. "123, 456, 789".
+fn parse_flatmates(raw: &str) -> Result<Vec<i64>, error::GstaldergeistError> {
+    raw.split(',')
         .map(|s| {
-            s.trim().parse().expect(
-                "TELEGRAM_FLATMATES must be a comma-separated list of numbers like 123,456,789",
-            )
+            let trimmed = s.trim();
+            trimmed.parse::<i64>().map_err(|_| {
+                error::GstaldergeistError::ConfigError(format!(
+                    "TELEGRAM_FLATMATES must be a comma-separated list of numbers like \
+                     123,456,789, got '{}'",
+                    trimmed
+                ))
+            })
         })
-        .collect();
+        .collect()
+}
+
+fn config() -> Result<Config, error::GstaldergeistError> {
+    let bot_token = required_env("TELEGRAM_BOT_TOKEN")?;
+    let channel_id_str = required_env("TELEGRAM_CHANNEL_ID")?;
+    let channel_id: i64 = channel_id_str.trim().parse().map_err(|_| {
+        error::GstaldergeistError::ConfigError("TELEGRAM_CHANNEL_ID must be a number".to_string())
+    })?;
+    let flatmates = parse_flatmates(&required_env("TELEGRAM_FLATMATES")?)?;
 
     Ok(Config {
         flatmates,
@@ -167,5 +180,48 @@ async fn send_scheduled_messages(
         }
         next_trigger = compute_next_trigger();
         shared_task.lock().unwrap().next_trigger = next_trigger;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_flatmates_single_value() {
+        assert_eq!(parse_flatmates("123").unwrap(), vec![123]);
+    }
+
+    #[test]
+    fn parse_flatmates_multiple_values() {
+        assert_eq!(parse_flatmates("123,456,789").unwrap(), vec![123, 456, 789]);
+    }
+
+    #[test]
+    fn parse_flatmates_trims_whitespace() {
+        assert_eq!(
+            parse_flatmates(" 123 , 456 ,789 ").unwrap(),
+            vec![123, 456, 789]
+        );
+    }
+
+    #[test]
+    fn parse_flatmates_accepts_negative_ids() {
+        // Telegram group/channel chat ids are negative.
+        assert_eq!(
+            parse_flatmates("-1001234567890,42").unwrap(),
+            vec![-1001234567890, 42]
+        );
+    }
+
+    #[test]
+    fn parse_flatmates_rejects_non_numeric() {
+        let err = parse_flatmates("123,abc,789").unwrap_err();
+        assert!(matches!(err, error::GstaldergeistError::ConfigError(_)));
+    }
+
+    #[test]
+    fn parse_flatmates_rejects_empty_string() {
+        assert!(parse_flatmates("").is_err());
     }
 }


### PR DESCRIPTION
## What
- Rework `config()` so it returns real `GstaldergeistError::ConfigError`
  values instead of unwinding through `.expect()` on every field.
- Extract a small, pure `parse_flatmates` helper (plus a `required_env`
  helper) and cover it with unit tests.
- Drop the now-unnecessary `#[allow(dead_code)]` on the `ConfigError`
  variant, which was never constructed before.

## Why
`config()` already advertised a `Result<Config, GstaldergeistError>`
signature, but every step used `.expect(...)`, so any misconfiguration
panicked the process at startup and the `Result` was effectively
decorative. The `ConfigError` error variant existed solely to be
silenced as dead code. Routing failures through `ConfigError` makes the
error path honest, keeps the failure message in one place, and lets the
binary surface a clean error instead of a panic backtrace.

The flatmate-id list is the most error-prone field to parse (split,
trim, integer parse), so pulling it into `parse_flatmates` makes it
unit-testable without touching environment variables.

## Notes
- Files touched: `src/main.rs` (config refactor + tests), `src/error.rs`
  (remove `dead_code` allow).
- Added 6 unit tests for `parse_flatmates` covering single/multiple
  values, whitespace trimming, negative chat ids, and rejection of
  non-numeric and empty input.
- No behaviour change for valid configuration; invalid configuration now
  yields a `ConfigError` instead of a panic.
- `cargo build`, `cargo test` (6 passed), and `cargo clippy` all green;
  clippy warning count is unchanged (no new warnings introduced).