### PR TITLE
Make the food-master name lookup panic-safe

### DIFF
--- a/src/data_grabber.rs
+++ b/src/data_grabber.rs
@@ -94,14 +94,9 @@ fn tomorrow_food_master_id(config: &super::Config) -> i64 {
     food_master_id(&config.flatmates, tomorrow)
 }
 
-/// Number of leading characters in a flatmate's Telegram chat title that make
-/// up a fixed label; the food master's display name is whatever follows it.
 const FOOD_MASTER_TITLE_PREFIX_LEN: usize = 17;
 
-/// Extracts the food master's display name from their Telegram chat title by
-/// dropping the fixed prefix. Unlike `String::split_off`, this never panics on
-/// short titles or multi-byte characters: a title shorter than the prefix
-/// simply yields an empty name.
+// Skip by chars, not bytes, so a short or multi-byte title never panics.
 fn food_master_name_from_title(title: &str) -> String {
     title.chars().skip(FOOD_MASTER_TITLE_PREFIX_LEN).collect()
 }
@@ -164,7 +159,6 @@ mod tests {
 
     #[test]
     fn drops_the_fixed_prefix() {
-        // 17-character prefix followed by the actual name.
         assert_eq!(food_master_name_from_title("Gstaldergeist || Alice"), "Alice");
     }
 
@@ -176,13 +170,11 @@ mod tests {
 
     #[test]
     fn prefix_length_boundary_yields_empty_name() {
-        // Exactly the prefix length: nothing remains after dropping it.
         assert_eq!(food_master_name_from_title("17_characters_xyz"), "");
     }
 
     #[test]
     fn counts_characters_not_bytes_for_multibyte_names() {
-        // A multi-byte character right after the prefix must not be split mid-byte.
         assert_eq!(
             food_master_name_from_title("Gstaldergeist || Élodie"),
             "Élodie"

--- a/src/data_grabber.rs
+++ b/src/data_grabber.rs
@@ -91,6 +91,18 @@ async fn tomorrow_food_master_id(config: &super::Config) -> i64 {
     chat_id
 }
 
+/// Number of leading characters in a flatmate's Telegram chat title that make
+/// up a fixed label; the food master's display name is whatever follows it.
+const FOOD_MASTER_TITLE_PREFIX_LEN: usize = 17;
+
+/// Extracts the food master's display name from their Telegram chat title by
+/// dropping the fixed prefix. Unlike `String::split_off`, this never panics on
+/// short titles or multi-byte characters: a title shorter than the prefix
+/// simply yields an empty name.
+fn food_master_name_from_title(title: &str) -> String {
+    title.chars().skip(FOOD_MASTER_TITLE_PREFIX_LEN).collect()
+}
+
 pub async fn grab_tomorrow_food_master_name(config: &super::Config) -> String {
     let tomorrow = chrono::Local::now().naive_local().date() + chrono::Duration::days(1);
     let client = reqwest::Client::new();
@@ -104,18 +116,12 @@ pub async fn grab_tomorrow_food_master_name(config: &super::Config) -> String {
         bot_token, chat_id
     );
 
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .unwrap()
-        .json::<ChatResult>()
-        .await;
+    let response = match client.get(url).send().await {
+        Ok(response) => response.json::<ChatResult>().await,
+        Err(_) => return "Error".to_string(),
+    };
     match response {
-        Ok(response) => {
-            let mut chat_info = response.result;
-            chat_info.title.split_off(17)
-        }
+        Ok(response) => food_master_name_from_title(&response.result.title),
         Err(_) => "Error".to_string(),
     }
 }
@@ -144,4 +150,36 @@ pub async fn get_trashes(
         tomorrow_master_name: grab_tomorrow_food_master_name(config).await,
         tomorrow_master_id: tomorrow_food_master_id(config).await,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::food_master_name_from_title;
+
+    #[test]
+    fn drops_the_fixed_prefix() {
+        // 17-character prefix followed by the actual name.
+        assert_eq!(food_master_name_from_title("Gstaldergeist || Alice"), "Alice");
+    }
+
+    #[test]
+    fn short_title_yields_empty_name_instead_of_panicking() {
+        assert_eq!(food_master_name_from_title("too short"), "");
+        assert_eq!(food_master_name_from_title(""), "");
+    }
+
+    #[test]
+    fn prefix_length_boundary_yields_empty_name() {
+        // Exactly the prefix length: nothing remains after dropping it.
+        assert_eq!(food_master_name_from_title("17_characters_xyz"), "");
+    }
+
+    #[test]
+    fn counts_characters_not_bytes_for_multibyte_names() {
+        // A multi-byte character right after the prefix must not be split mid-byte.
+        assert_eq!(
+            food_master_name_from_title("Gstaldergeist || Élodie"),
+            "Élodie"
+        );
+    }
 }


### PR DESCRIPTION
## What
Hardens `grab_tomorrow_food_master_name` in `src/data_grabber.rs` against two
panic hazards and adds unit tests for the name-extraction logic.

- Replaces `title.split_off(17)` with a dedicated, panic-safe helper
  `food_master_name_from_title`. `split_off` panics when the title is shorter
  than 17 bytes or when byte 17 falls inside a multi-byte UTF-8 character; the
  new helper drops the fixed 17-*character* prefix and yields an empty name
  instead of crashing.
- Stops `.send().await.unwrap()` from panicking on transient network errors.
  A failed request now degrades to the same `"Error"` fallback that a failed
  JSON decode already used, so a hiccup contacting the Telegram API no longer
  brings down the scheduled task.

## Why
This function runs inside the scheduled-message task. A short/unexpected chat
title or a momentary network blip would panic the task and silence the bot.
The lookup should fail soft, exactly as the existing JSON-error branch already
intended.

## Notes
- Files touched: `src/data_grabber.rs` (logic + new `#[cfg(test)] mod tests`).
- Extracted the prefix-stripping into a pure function so it can be tested
  without network access; covers the normal case, short titles, the exact
  prefix-length boundary, and multi-byte names.
- Distinct from the open rotation-logic PR (#142), which only touches the
  flatmate-index computation, not the name parsing or network handling.
- Build & tests: `cargo build` and `cargo test` both green (4 tests pass).