### PR TITLE
Stop a transient Telegram error in the weekly update from killing the scheduler

### DIFF
--- a/src/telegram_writer.rs
+++ b/src/telegram_writer.rs
@@ -54,16 +54,18 @@ async fn weekly_update(bot: &Bot, config: &super::Config, schedule: &TrashesSche
         {}",
         schedule.tomorrow_master_name, master_update_txt
     );
-    bot.send_message(ChatId(schedule.tomorrow_master_id), &master_update_txt)
-        .await
-        .unwrap();
+    send(bot, schedule.tomorrow_master_id, &master_update_txt).await;
 
     let request_bags_txt =
         format!("Can you look if we still have enough We-Recycle bags? Do we need to order new?");
-    bot.send_message(ChatId(schedule.tomorrow_master_id), &request_bags_txt)
+    match bot
+        .send_message(ChatId(schedule.tomorrow_master_id), &request_bags_txt)
         .reply_markup(keyboard)
         .await
-        .unwrap();
+    {
+        Ok(_) => tracing::info!("Scheduled message sent successfully"),
+        Err(e) => tracing::error!("Error sending scheduled message: {}", e),
+    }
 }
 
 async fn daily_update(


### PR DESCRIPTION
## What
Replaces the two `bot.send_message(...).await.unwrap()` calls in
`weekly_update` (`src/telegram_writer.rs`) with graceful error handling that
logs and continues, matching the rest of the module.

- The plain food-master message now goes through the existing `send()` helper.
- The "do we need new bags?" message (which carries an inline keyboard, so it
  can't use `send()`) now logs the error inline, mirroring `daily_update`.

## Why
`weekly_update` runs inside the spawned `send_scheduled_messages` task. A
transient Telegram failure — a rate-limit, a network blip, a 5xx from the API —
would make `.unwrap()` panic that task. The bot process keeps running, so the
failure is silent, but **all future reminders stop** until the bot is
restarted.

This is the same class of bug that PR #140 addresses for the data-collection
path; this change closes the gap on the message-sending path. The module
already handles this correctly everywhere else: the `send()` helper and
`daily_update` both log-and-continue on send errors. `weekly_update` was the
lone outlier still using `.unwrap()`.

## Notes
- Single file touched: `src/telegram_writer.rs`.
- No behavioural change on the happy path; only the failure path changes
  (panic → logged error).
- `cargo build` passes; no new clippy warnings introduced (the pre-existing
  `useless_format`/`needless_borrow` warnings are unrelated).