### PR TITLE
Make the scheduler's next-trigger calculation pure, testable, and exact

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,18 +114,41 @@ async fn control_human_accomplishment(
 }
 
 fn compute_next_trigger() -> chrono::DateTime<chrono::Local> {
-    let now = chrono::Local::now();
+    next_trigger_after(chrono::Local::now())
+}
+
+/// Returns the next scheduled trigger relative to `now`.
+///
+/// Triggers happen at 16:00 (send the order) and 19:00 (control the
+/// accomplishment). Before 16:00 the next trigger is today at 16:00, between
+/// 16:00 and 19:00 it is today at 19:00, and from 19:00 onwards it rolls over
+/// to 16:00 the next day.
+fn next_trigger_after(
+    now: chrono::DateTime<chrono::Local>,
+) -> chrono::DateTime<chrono::Local> {
     if now.hour() < 16 {
-        now.with_hour(16).unwrap().with_minute(0).unwrap()
+        at_hour(now, 16)
     } else if now.hour() < 19 {
-        now.with_hour(19).unwrap().with_minute(0).unwrap()
+        at_hour(now, 19)
     } else {
-        (now + chrono::Duration::days(1))
-            .with_hour(16)
-            .unwrap()
-            .with_minute(0)
-            .unwrap()
+        at_hour(now + chrono::Duration::days(1), 16)
     }
+}
+
+/// Returns `dt` at the given whole hour, with minutes, seconds and
+/// sub-seconds zeroed so the trigger lands exactly on the hour.
+fn at_hour(
+    dt: chrono::DateTime<chrono::Local>,
+    hour: u32,
+) -> chrono::DateTime<chrono::Local> {
+    dt.with_hour(hour)
+        .unwrap()
+        .with_minute(0)
+        .unwrap()
+        .with_second(0)
+        .unwrap()
+        .with_nanosecond(0)
+        .unwrap()
 }
 
 async fn collect_trashes_data(
@@ -167,5 +190,67 @@ async fn send_scheduled_messages(
         }
         next_trigger = compute_next_trigger();
         shared_task.lock().unwrap().next_trigger = next_trigger;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn local(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> chrono::DateTime<chrono::Local> {
+        chrono::Local
+            .with_ymd_and_hms(year, month, day, hour, min, sec)
+            .single()
+            .expect("unambiguous local time")
+    }
+
+    #[test]
+    fn before_first_trigger_schedules_today_at_16() {
+        let now = local(2026, 6, 7, 9, 30, 12);
+        assert_eq!(next_trigger_after(now), local(2026, 6, 7, 16, 0, 0));
+    }
+
+    #[test]
+    fn between_triggers_schedules_today_at_19() {
+        let now = local(2026, 6, 7, 16, 30, 45);
+        assert_eq!(next_trigger_after(now), local(2026, 6, 7, 19, 0, 0));
+    }
+
+    #[test]
+    fn after_last_trigger_rolls_over_to_next_day_at_16() {
+        let now = local(2026, 6, 7, 19, 5, 0);
+        assert_eq!(next_trigger_after(now), local(2026, 6, 8, 16, 0, 0));
+    }
+
+    #[test]
+    fn at_16_exactly_schedules_19_same_day() {
+        let now = local(2026, 6, 7, 16, 0, 0);
+        assert_eq!(next_trigger_after(now), local(2026, 6, 7, 19, 0, 0));
+    }
+
+    #[test]
+    fn at_19_exactly_rolls_over_to_next_day() {
+        let now = local(2026, 6, 7, 19, 0, 0);
+        assert_eq!(next_trigger_after(now), local(2026, 6, 8, 16, 0, 0));
+    }
+
+    #[test]
+    fn trigger_zeroes_minutes_seconds_and_subseconds() {
+        // 15:59:59 must round to 16:00:00, not carry the 59 seconds over.
+        let now = local(2026, 6, 7, 15, 59, 59)
+            .with_nanosecond(987_654_321)
+            .unwrap();
+        let next = next_trigger_after(now);
+        assert_eq!(next.minute(), 0);
+        assert_eq!(next.second(), 0);
+        assert_eq!(next.nanosecond(), 0);
+        assert_eq!(next, local(2026, 6, 7, 16, 0, 0));
+    }
+
+    #[test]
+    fn rollover_keeps_month_and_year_boundaries() {
+        let now = local(2026, 12, 31, 20, 0, 0);
+        assert_eq!(next_trigger_after(now), local(2027, 1, 1, 16, 0, 0));
     }
 }


### PR DESCRIPTION
## What
- Extracts the scheduling logic out of `compute_next_trigger` into a pure
  `next_trigger_after(now)` helper that takes the current time as an argument,
  so it can be unit-tested without depending on the wall clock.
- Fixes a truncation bug: the old code only zeroed the *minutes*, leaving the
  current seconds and sub-seconds in place. A trigger meant for `16:00:00` was
  actually scheduled at e.g. `16:00:45.123`. The new `at_hour` helper zeroes
  minutes, seconds and nanoseconds so triggers land exactly on the hour.
- Adds 7 unit tests covering the before/between/after windows, the exact-hour
  boundaries, the sub-second truncation, and the day/month/year rollover.

## Why
- `compute_next_trigger` read `Local::now()` directly, making its branching
  logic impossible to test.
- Because seconds weren't reset, every scheduled trigger drifted by up to 59
  seconds past the intended time — small but real, and easy to fix once the
  logic is isolated.

## Notes
- Files touched: `src/main.rs` (refactor + new `at_hour` helper + `#[cfg(test)]`
  module). Behaviour of the 16:00/19:00 schedule is unchanged apart from the
  seconds fix.
- This is the first test module in the crate.
- Distinct from the open PRs (config parsing, scheduler resilience, food-master
  logic, trash formatting, PDF/Adliswil date extraction) — none touch the
  next-trigger calculation.
- `cargo build`: clean, no warnings. `cargo test`: 7 passed, 0 failed.