### PR TITLE
Make the bag-request email flow fail gracefully instead of panicking and lying

### DIFF
--- a/src/answer_handler.rs
+++ b/src/answer_handler.rs
@@ -104,13 +104,15 @@ async fn confirm_request_bags_handler(
     };
     let chat_id = message.chat().id;
 
-    bot.edit_message_text(
-        chat_id,
-        message.id(),
-        "Thank you! I sent a request to We-Recycle.",
-    )
-    .await?;
-    email::request_new_bags();
+    let reply = match email::request_new_bags() {
+        Ok(()) => "Thank you! I sent a request to We-Recycle.",
+        Err(e) => {
+            tracing::error!("Failed to send bag request email: {}", e);
+            "Sorry, I couldn't send the request to We-Recycle. Please try again later."
+        }
+    };
+
+    bot.edit_message_text(chat_id, message.id(), reply).await?;
     Ok(())
 }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -29,10 +29,10 @@ impl EmailConfig {
     }
 }
 
-pub fn request_new_bags() {
-    let email_config = EmailConfig::from_env().unwrap();
+pub fn request_new_bags() -> Result<(), Box<dyn Error>> {
+    let email_config = EmailConfig::from_env()?;
 
-    let res = send_email(
+    send_email(
         &email_config,
         email_config.to_email.as_str(),
         "We Recycle",
@@ -54,11 +54,9 @@ pub fn request_new_bags() {
             )
             .as_str(),
         ),
-    );
-    match res {
-        Ok(_) => tracing::info!("Email sent successfully"),
-        Err(e) => tracing::error!("Error sending email: {}", e),
-    }
+    )?;
+    tracing::info!("Email sent successfully");
+    Ok(())
 }
 
 fn send_email(


### PR DESCRIPTION
## What
- `email::request_new_bags()` now returns `Result<(), Box<dyn Error>>` and
  propagates configuration/SMTP errors instead of unwrapping them.
- `confirm_request_bags_handler` reacts to that result: it confirms success
  only when the email was actually sent, and otherwise tells the user the
  request could not be sent (and logs the error).

## Why
The old flow had two problems when a user pressed "NEW BAGS !!!":

- `EmailConfig::from_env().unwrap()` panicked the handler if any email env
  var was missing or invalid, crashing that callback instead of degrading
  gracefully.
- The handler edited the message to *"Thank you! I sent a request to
  We-Recycle."* **before** attempting to send, so the user was always told
  the request succeeded even when sending failed.

## Notes
- Files touched: `src/email.rs`, `src/answer_handler.rs`.
- Distinct from the open PRs (scheduler, weekly-update Telegram errors,
  food-master logic, config parsing, PDF/Adliswil grabbers, trash
  formatting); none touch the email or bag-request path.
- Build status: `cargo build` clean. `cargo clippy` produces only
  pre-existing warnings unrelated to these files.