### PR TITLE
Match the We-Recycle collection region by whole number, not substring

### DIFF
--- a/src/data_grabber/we_recycle.rs
+++ b/src/data_grabber/we_recycle.rs
@@ -7,6 +7,20 @@ use std::collections::HashMap;
 
 pub struct WeRecycleWasteGrabber;
 
+/// The flat's We-Recycle collection region.
+const COLLECTION_REGION: u32 = 19;
+
+/// True if `regions` lists `target` as a standalone number. The regions column
+/// is a space/`+`/`-` separated list of region numbers, so we compare whole
+/// tokens rather than substrings — otherwise `190` or `119` would falsely match
+/// region `19`.
+fn regions_include(regions: &str, target: u32) -> bool {
+    regions
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|token| token.parse::<u32>().ok())
+        .any(|region| region == target)
+}
+
 #[async_trait::async_trait]
 impl super::WasteGrabber for WeRecycleWasteGrabber {
     async fn get_trashes(
@@ -32,7 +46,7 @@ fn regex_caps_to_datetime(caps: &regex::Captures) -> Option<NaiveDate> {
     let date = &caps[1];
 
     if let Some(regions) = caps.get(3) {
-        if regions.as_str().contains("19") {
+        if regions_include(regions.as_str(), COLLECTION_REGION) {
             let current_year = chrono::Utc::now().date_naive().year();
             let naive_date =
                 chrono::NaiveDate::parse_from_str(&format!("{}{}", date, current_year), "%d.%m.%Y")
@@ -132,6 +146,17 @@ mod tests {
         // Region 19 can appear among several space/plus/dash separated regions.
         let dates = extract_dates_from_txt("12.07. SA 7 + 19 - 20 ".to_string()).unwrap();
         assert_eq!(dates, vec![date(12, 7)]);
+    }
+
+    #[test]
+    fn ignores_region_numbers_that_merely_contain_19() {
+        // "190" and "119" contain "19" as a substring but are not region 19.
+        assert!(extract_dates_from_txt("05.06. FR 190 ".to_string())
+            .unwrap()
+            .is_empty());
+        assert!(extract_dates_from_txt("05.06. FR 119 ".to_string())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What
In `src/data_grabber/we_recycle.rs`, the filter that keeps only the flat's
collection rows used `regions.as_str().contains("19")`. This replaces the
substring check with `regions_include`, which splits the regions column into
numeric tokens and matches region `19` as a whole number. The literal `19` is
also lifted into a named `COLLECTION_REGION` constant.

## Why
The regions column is a space/`+`/`-` separated list of region numbers. A
substring match treats any value that merely *contains* `19` as a hit, so rows
for regions like `190`, `192`, or `119` were falsely picked up as We-Recycle
collection days — scheduling bag reminders on the wrong dates.

## Notes
- Files touched: `src/data_grabber/we_recycle.rs` only (no overlap with the
  open PRs #148 / #150).
- Added a regression test (`ignores_region_numbers_that_merely_contain_19`)
  covering `190` and `119`; existing region tests (standalone `19`, ranges like
  `7 + 19 - 20`, other regions) still pass.
- `cargo test` green (35 passed). No new clippy warnings from this change.