### PR TITLE
Make the database layer testable and cover it with round-trip tests

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9,15 +9,21 @@ const DB_PATH: &str = "/data/gstaldergeist.db";
 /// Open the database and make sure the `trashes` table exists.
 fn open_db() -> Result<Connection, GstaldergeistError> {
     let conn = Connection::open(DB_PATH)?;
+    init_schema(&conn)?;
+    Ok(conn)
+}
+
+fn init_schema(conn: &Connection) -> Result<(), GstaldergeistError> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS trashes (date DATE, waste_type INTEGER)",
         [],
     )?;
-    Ok(conn)
+    Ok(())
 }
 
-pub fn get_all_trashes() -> Result<HashMap<NaiveDate, Vec<TrashType>>, GstaldergeistError> {
-    let conn = open_db()?;
+fn read_all_trashes(
+    conn: &Connection,
+) -> Result<HashMap<NaiveDate, Vec<TrashType>>, GstaldergeistError> {
     let mut stmt = conn.prepare("SELECT date, waste_type FROM trashes")?;
     let rows = stmt.query_map([], |row| {
         let date: NaiveDate = row.get(0)?;
@@ -32,10 +38,10 @@ pub fn get_all_trashes() -> Result<HashMap<NaiveDate, Vec<TrashType>>, Gstalderg
     Ok(trashes)
 }
 
-pub fn set_trashes(trashes: &HashMap<NaiveDate, Vec<TrashType>>) -> Result<(), GstaldergeistError> {
-    let conn = open_db()?;
-
-    // delete all rows
+fn write_trashes(
+    conn: &Connection,
+    trashes: &HashMap<NaiveDate, Vec<TrashType>>,
+) -> Result<(), GstaldergeistError> {
     conn.execute("DELETE FROM trashes", [])?;
 
     let mut stmt = conn.prepare("INSERT INTO trashes (date, waste_type) VALUES (?1, ?2)")?;
@@ -45,4 +51,73 @@ pub fn set_trashes(trashes: &HashMap<NaiveDate, Vec<TrashType>>) -> Result<(), G
         }
     }
     Ok(())
+}
+
+pub fn get_all_trashes() -> Result<HashMap<NaiveDate, Vec<TrashType>>, GstaldergeistError> {
+    read_all_trashes(&open_db()?)
+}
+
+pub fn set_trashes(trashes: &HashMap<NaiveDate, Vec<TrashType>>) -> Result<(), GstaldergeistError> {
+    write_trashes(&open_db()?, trashes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn display_sorted(types: &[TrashType]) -> Vec<String> {
+        let mut names: Vec<String> = types.iter().map(|t| t.to_string()).collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn empty_table_reads_back_empty() {
+        let conn = mem_db();
+        assert!(read_all_trashes(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn written_trashes_round_trip() {
+        let conn = mem_db();
+        let mut input = HashMap::new();
+        input.insert(date(2026, 6, 12), vec![TrashType::Normal, TrashType::Bio]);
+        input.insert(date(2026, 6, 14), vec![TrashType::Paper]);
+
+        write_trashes(&conn, &input).unwrap();
+        let output = read_all_trashes(&conn).unwrap();
+
+        assert_eq!(output.len(), 2);
+        for (date, types) in &input {
+            assert_eq!(display_sorted(&output[date]), display_sorted(types));
+        }
+    }
+
+    #[test]
+    fn write_replaces_previous_contents() {
+        let conn = mem_db();
+
+        let mut first = HashMap::new();
+        first.insert(date(2026, 6, 12), vec![TrashType::Cardboard]);
+        write_trashes(&conn, &first).unwrap();
+
+        let mut second = HashMap::new();
+        second.insert(date(2026, 6, 13), vec![TrashType::WeRecycle]);
+        write_trashes(&conn, &second).unwrap();
+
+        let output = read_all_trashes(&conn).unwrap();
+        assert_eq!(output.len(), 1);
+        assert!(!output.contains_key(&date(2026, 6, 12)));
+        assert_eq!(display_sorted(&output[&date(2026, 6, 13)]), vec!["WeRecycle"]);
+    }
 }


### PR DESCRIPTION
## What
Split `src/database.rs` so the SQL logic no longer depends on opening the
hardcoded production database path:

- `init_schema(&Connection)` creates the `trashes` table.
- `read_all_trashes(&Connection)` / `write_trashes(&Connection, …)` hold the
  actual query logic and operate on a borrowed connection.
- The public `get_all_trashes()` / `set_trashes()` keep their signatures and
  just open the real DB and delegate.

Adds a `tests` module that runs the read/write helpers against an in-memory
SQLite connection, covering:

- empty table reads back empty,
- a write/read round-trip across multiple dates and waste types,
- a second write fully replacing the previous contents.

## Why
The query logic was welded to `Connection::open("/data/gstaldergeist.db")`, so
none of it could be exercised in tests. Separating "which database" from "what
to do with it" lets the SQL (and the `TrashType` ⇄ integer encoding it relies
on) be verified in isolation, with no behavioural change to callers.

## Notes
- Scope: `src/database.rs` only — does not overlap with the open PRs (#150–#153).
- `cargo test`: 37 passed (3 new). Pre-existing clippy warnings live in other
  files and are untouched here.