### PR TITLE
Make the done-handler's next-trigger calculation pure, safe, and tested

### DIFF
--- a/src/answer_handler.rs
+++ b/src/answer_handler.rs
@@ -1,7 +1,7 @@
 use crate::SharedTaskState;
 use crate::TaskState;
 use crate::email;
-use chrono::{Datelike, TimeZone};
+use chrono::TimeZone;
 use teloxide::prelude::*;
 use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup, MessageId};
 
@@ -18,20 +18,21 @@ async fn done_handler(
     let mut task_state = task_state.lock().unwrap();
     if task_state.state == TaskState::Pending {
         task_state.state = TaskState::None;
-        let tomorrow = chrono::Local::now() + chrono::Duration::days(1);
-        let tomorrow_evening = chrono::Local
-            .with_ymd_and_hms(
-                tomorrow.year(),
-                tomorrow.month(),
-                tomorrow.day(),
-                18,
-                00,
-                00,
-            )
-            .unwrap();
-        task_state.next_trigger = tomorrow_evening;
+        task_state.next_trigger = next_evening_trigger(chrono::Local::now());
     }
     return Ok(());
+}
+
+/// 18:00 local on the day after `now`. The hour is fixed and never lands on a
+/// DST transition, so the resulting local time is always unambiguous.
+fn next_evening_trigger(
+    now: chrono::DateTime<chrono::Local>,
+) -> chrono::DateTime<chrono::Local> {
+    let tomorrow = now.date_naive() + chrono::Duration::days(1);
+    tomorrow
+        .and_hms_opt(18, 0, 0)
+        .and_then(|naive| now.timezone().from_local_datetime(&naive).single())
+        .expect("18:00 is always a valid, unambiguous local time")
 }
 
 async fn cant_handler(
@@ -191,4 +192,45 @@ pub async fn handle_message(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    fn local(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> chrono::DateTime<chrono::Local> {
+        chrono::Local
+            .with_ymd_and_hms(year, month, day, hour, min, sec)
+            .single()
+            .expect("unambiguous local time")
+    }
+
+    #[test]
+    fn triggers_at_18_the_following_day() {
+        let now = local(2026, 6, 13, 16, 30, 0);
+        assert_eq!(next_evening_trigger(now), local(2026, 6, 14, 18, 0, 0));
+    }
+
+    #[test]
+    fn rolls_over_month_and_year_boundaries() {
+        assert_eq!(
+            next_evening_trigger(local(2026, 6, 30, 20, 0, 0)),
+            local(2026, 7, 1, 18, 0, 0)
+        );
+        assert_eq!(
+            next_evening_trigger(local(2026, 12, 31, 23, 59, 59)),
+            local(2027, 1, 1, 18, 0, 0)
+        );
+    }
+
+    #[test]
+    fn zeroes_minutes_seconds_and_subseconds() {
+        let now = local(2026, 6, 13, 16, 45, 31)
+            .with_nanosecond(123_456_789)
+            .unwrap();
+        let next = next_evening_trigger(now);
+        assert_eq!((next.hour(), next.minute(), next.second()), (18, 0, 0));
+        assert_eq!(next.nanosecond(), 0);
+    }
 }


### PR DESCRIPTION
## What
Extracts the "next trigger" time computed when a food master taps **Done**
into a small pure function, `next_evening_trigger(now)`, and covers it with
unit tests.

## Why
The logic was inlined in `done_handler` and built the timestamp with
`Local.with_ymd_and_hms(...).unwrap()`, which panics on an unrepresentable
local time. It was also untestable because it read the clock directly.

Pulling it into a pure function lets us pass a fixed `now`, makes the
month/year rollover behaviour explicit, and resolves the local time with
`from_local_datetime(..).single()` (matching the approach already used by the
scheduler's `at_hour` in `main.rs`, see #145).

## Notes
- Files touched: `src/answer_handler.rs` only — a file no open PR modifies.
- Drops the now-unused `Datelike` import.
- Adds 3 tests (following-day at 18:00, month/year rollover, zeroed
  minutes/seconds/subseconds).
- Build clean, `cargo test` green: 37 passed (was 34).