### PR TITLE
Use thiserror's `#[from]` for the wrapping error conversions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,16 @@
 #[derive(thiserror::Error, Debug)]
 pub enum GstaldergeistError {
     #[error("Telegram error: {0}")]
-    TelegramError(teloxide::RequestError),
+    TelegramError(#[from] teloxide::RequestError),
 
     #[error("Network error: {0}")]
-    NetworkError(reqwest::Error),
+    NetworkError(#[from] reqwest::Error),
 
     #[error("Configuration error: {0}")]
     ConfigError(String),
 
     #[error("Date parsing error: {0}")]
-    DateError(chrono::ParseError),
+    DateError(#[from] chrono::ParseError),
 
     #[error("Pdf extract error: {0}")]
     PdfExtract(String),
@@ -19,6 +19,8 @@ pub enum GstaldergeistError {
     Other(String),
 }
 
+// These conversions collapse the source error into a String message, which
+// `#[from]` can't express, so they stay explicit.
 impl From<std::io::Error> for GstaldergeistError {
     fn from(error: std::io::Error) -> Self {
         GstaldergeistError::Other(error.to_string())
@@ -28,24 +30,6 @@ impl From<std::io::Error> for GstaldergeistError {
 impl From<serde_json::Error> for GstaldergeistError {
     fn from(error: serde_json::Error) -> Self {
         GstaldergeistError::Other(error.to_string())
-    }
-}
-
-impl From<teloxide::RequestError> for GstaldergeistError {
-    fn from(error: teloxide::RequestError) -> Self {
-        GstaldergeistError::TelegramError(error)
-    }
-}
-
-impl From<reqwest::Error> for GstaldergeistError {
-    fn from(error: reqwest::Error) -> Self {
-        GstaldergeistError::NetworkError(error)
-    }
-}
-
-impl From<chrono::ParseError> for GstaldergeistError {
-    fn from(error: chrono::ParseError) -> Self {
-        GstaldergeistError::DateError(error)
     }
 }
 


### PR DESCRIPTION
## What
Replaces three hand-written `From` impls in `src/error.rs` with `thiserror`'s
`#[from]` derive on the variants that simply wrap their source error:

- `TelegramError(teloxide::RequestError)`
- `NetworkError(reqwest::Error)`
- `DateError(chrono::ParseError)`

The `From` impls that collapse a source error into a `String` message
(`io`, `serde_json`, `regex`, `lopdf`, `rusqlite`) stay explicit, since
`#[from]` can't express that lossy conversion. A short comment notes why.

## Why
Those three `From` impls were pure boilerplate — `#[from]` generates exactly
the same conversion, so deriving it removes ~15 lines and keeps the error type
idiomatic. A clear rule now separates the two groups: wrap-only variants derive
`#[from]`; String-collapsing variants are written out.

## Notes
- Single file touched: `src/error.rs`. No call sites change — the generated
  `From` impls are identical, so all existing `?` conversions still compile.
- `cargo build` clean; `cargo test` green (34 passed).