### PR TITLE
Update the README project-structure tree to match the actual source layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,14 @@ TO_EMAIL="we-recycle@gmail.com"
 
 ```
 src/
-├── main.rs          # Main bot implementation
-├── email.rs         # Email handling functionality
-└── data_grabber/    # Data collection modules
+├── main.rs            # Entry point: config, scheduler, dispatcher wiring
+├── answer_handler.rs  # Telegram message and callback-query handlers
+├── telegram_writer.rs # Composing and sending Telegram messages
+├── database.rs        # SQLite persistence of the trash schedule
+├── email.rs           # Email notifications (We-Recycle bag requests)
+├── error.rs           # Shared error type
+├── data_grabber.rs    # Grabber orchestration, trash types, food-master rotation
+└── data_grabber/      # Per-service waste-data collection
     ├── we_recycle.rs
     └── adliswil.rs
 ```


### PR DESCRIPTION
## What
Refreshes the "Project Structure" section of `README.md` so it lists every
source module that actually exists, with a one-line description of each.

## Why
The documented tree was stale: it showed only `main.rs`, `email.rs`, and the
two `data_grabber/` sub-modules, while the codebase has since grown
`answer_handler.rs`, `telegram_writer.rs`, `database.rs`, `error.rs`, and the
`data_grabber.rs` module file. A newcomer reading the README got a misleading
picture of where things live.

## Notes
- Docs-only change: `README.md` only — no source or behaviour changes.
- Distinct from the open code PRs, none of which touch documentation.
- `cargo build` / `cargo test` unaffected (no code touched).