### PR TITLE
Deduplicate and test the collection-window filter shared by the grabbers

### DIFF
--- a/src/data_grabber.rs
+++ b/src/data_grabber.rs
@@ -76,6 +76,13 @@ impl fmt::Display for TrashType {
     }
 }
 
+/// Whether a collection on `date` belongs in the reminder window. The window is
+/// half-open as `(from, to]`: a collection on `from` itself is excluded (we only
+/// remind about upcoming days), while `to` is included.
+pub(crate) fn is_in_collection_window(date: NaiveDate, from: NaiveDate, to: NaiveDate) -> bool {
+    date > from && date <= to
+}
+
 #[derive(Debug)]
 pub struct TrashesSchedule {
     pub dates: HashMap<NaiveDate, Vec<TrashType>>,
@@ -150,11 +157,56 @@ pub async fn get_trashes(
 
 #[cfg(test)]
 mod tests {
-    use super::{food_master_id, food_master_name_from_title};
+    use super::{food_master_id, food_master_name_from_title, is_in_collection_window};
     use chrono::NaiveDate;
 
     fn date(y: i32, m: u32, d: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn window_excludes_the_start_day() {
+        assert!(!is_in_collection_window(
+            date(2026, 6, 15),
+            date(2026, 6, 15),
+            date(2026, 6, 22)
+        ));
+    }
+
+    #[test]
+    fn window_includes_the_end_day() {
+        assert!(is_in_collection_window(
+            date(2026, 6, 22),
+            date(2026, 6, 15),
+            date(2026, 6, 22)
+        ));
+    }
+
+    #[test]
+    fn window_includes_a_day_inside_the_range() {
+        assert!(is_in_collection_window(
+            date(2026, 6, 16),
+            date(2026, 6, 15),
+            date(2026, 6, 22)
+        ));
+    }
+
+    #[test]
+    fn window_excludes_days_after_the_end() {
+        assert!(!is_in_collection_window(
+            date(2026, 6, 23),
+            date(2026, 6, 15),
+            date(2026, 6, 22)
+        ));
+    }
+
+    #[test]
+    fn window_excludes_days_before_the_start() {
+        assert!(!is_in_collection_window(
+            date(2026, 6, 14),
+            date(2026, 6, 15),
+            date(2026, 6, 22)
+        ));
     }
 
     #[test]

--- a/src/data_grabber/adliswil.rs
+++ b/src/data_grabber/adliswil.rs
@@ -63,7 +63,7 @@ impl super::WasteGrabber for AdliswilWasteGrabber {
 
             for event in wastes.results.events {
                 let naive = event.date.date_naive();
-                if naive > from && naive <= to {
+                if super::is_in_collection_window(naive, from, to) {
                     let trastype = match event.waste_type {
                         1 => super::TrashType::Normal,
                         2 => super::TrashType::Bio,

--- a/src/data_grabber/we_recycle.rs
+++ b/src/data_grabber/we_recycle.rs
@@ -17,7 +17,7 @@ impl super::WasteGrabber for WeRecycleWasteGrabber {
         let extracted_dates = download_pdf().await?;
         let mut result = HashMap::new();
         for date in extracted_dates {
-            if date > from && date <= to {
+            if super::is_in_collection_window(date, from, to) {
                 result
                     .entry(date)
                     .or_insert_with(Vec::new)


### PR DESCRIPTION
## What
Extracts the `(from, to]` collection-window check that both waste grabbers
inlined into a single `is_in_collection_window` helper in `data_grabber`, and
covers its boundary behaviour with unit tests.

## Why
`AdliswilWasteGrabber` and `WeRecycleWasteGrabber` each carried their own copy
of `date > from && date <= to`. The rule is subtle — the window is half-open,
so a collection **on** `from` (i.e. today) is intentionally dropped while `to`
is kept — and two copies can drift apart. Centralising it gives one source of
truth and a place to pin the boundary semantics with tests.

## Notes
- Files touched:
  - `src/data_grabber.rs` — new `is_in_collection_window` helper + tests.
  - `src/data_grabber/adliswil.rs`, `src/data_grabber/we_recycle.rs` — call the
    shared helper instead of the inline comparison.
- Behaviour is unchanged; this is a refactor plus added coverage.
- Build & tests: `cargo build` and `cargo test` both green (39 tests pass).